### PR TITLE
Lower the minium size of the packet heap.

### DIFF
--- a/src/main/java/minefantasy/mf2/network/packet/PacketMF.java
+++ b/src/main/java/minefantasy/mf2/network/packet/PacketMF.java
@@ -8,7 +8,7 @@ import net.minecraft.entity.player.EntityPlayer;
 public abstract class PacketMF {
 
 	public final FMLProxyPacket generatePacket() {
-		ByteBuf buf = Unpooled.buffer();
+		ByteBuf buf = Unpooled.buffer(16);
 		write(buf);
 		return new FMLProxyPacket(buf, getChannel());
 	}


### PR DESCRIPTION
The default size of a packet was 256, which can't be fully used by every packets, which caused the waste of network resource.
I limited it to 16(a really small size shorter than almost every packets), and it could be widened automatically when the data to transfer is longer than it.

We'll test it on our server and I'll comment here after it's proved stable. And you could merge this pull request after that.

Another small problem, the version needs to be changed in both build.gradle and MineFantasyII.java. I only changed it in build.gradle, which needs to be fixed.